### PR TITLE
Remove long test genrule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -51,11 +51,3 @@ gazelle(
     ],
     command = "update-repos",
 )
-
-##### TEMPORARY
-# TODO(Terrence Ho): Remove this
-genrule(
-    name = "hello20s",
-    outs = ["hello20s.txt"],
-    cmd_bash = "sleep 20 && echo 'hello20s' >$@",
-)


### PR DESCRIPTION
Remove a long genrule that was trying to test caching of github actions. The rule still took a long time to run (was not cached) but caching is not a concern for now. Removing for now to prevent long build times.