### PR TITLE
Properly account for n=0 case in fib

### DIFF
--- a/fib/fib.go
+++ b/fib/fib.go
@@ -19,6 +19,9 @@ func FibRecursive(n int) int {
 // function that recurses down to n = 1, and then builds the cache moving
 // backwards. The number at the greatest index is the resulting answer.
 func FibRecursiveCache(n int) int {
+	if n < 2 {
+		return n
+	}
 	cache := make([]int, n+1, n+1)
 	fibRecursiveCache(n, &cache)
 	return cache[n]
@@ -52,6 +55,9 @@ func fibTailRecursive(n, first, second int) int {
 // Linear, iterative implementation.  Uses a for loop, and pre delcares temp
 // variables to avoid initialization every loop.
 func FibIterative(n int) int {
+	if n < 2 {
+		return n
+	}
 	var temp int
 	first := 0
 	second := 1

--- a/fib/fib_test.go
+++ b/fib/fib_test.go
@@ -11,6 +11,7 @@ type fibTest struct {
 }
 
 var fibTests = []fibTest{
+	{0, 0},
 	{1, 1},
 	{2, 1},
 	{3, 2},


### PR DESCRIPTION
Previously, some of the functions did not account for n=0 as a test
case. This is not rectified and reflected in the test case. This also
bumps the test coverage of this library to 100%.