### PR TITLE
[utils-go] Add go error package

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,52 @@
+###############################
+# Settings for running builds #
+###############################
+
+# Cache action outputs on local disk so they persist across output_bae and bazel
+# shutdown (helps with cache thrashing when changing branches).
+build --disk_cache=~/.cache/bazel-disk-cache
+
+# show output files created by builds requested more than one target.
+# Helps locate build outputs.
+build --show_result=20
+
+# Turn off legacy external runfiles. Bazel will remove these soon.
+build --nolegacy_external_runfiles
+
+# Turn on --incompatible_strict_action_env. Ensures that bazel cache is not
+# invalidated when `yarn bazel` is run.
+build --incompatible_strict_action_env
+run --incompatible_strict_action_env
+
+# Avoid using random headers on a machine that can interfere with Bazel's C++
+# toolchains
+build --strict_system_includes
+
+# Don't automatically create __init__.py files. Developers must place these
+# files into the source tree themselves.
+build --incompatible_default_to_explicit_init_py
+
+##############################
+# Settings for running tests #
+##############################
+
+# complain about test size, encourage size="small" in test rules
+test --test_verbose_timeout_warnings
+
+# show test error outputs
+test --test_output=errors
+
+# show the test summary. Show detailed information about failed tests
+# test --test_summary=detailed
+
+
+############################
+# Settings for local users #
+############################
+
+# Try to import local user settings. The .bazelrc.user file is in the
+# .gitignore, so it will not be checked into source repo. This configuration
+# needs to be last. We use .bazelrc.user so that the file appears next to the
+# .bazelrc when listing directories.
+try-import %workspace%/.bazelrc.user
+# DO NOT ADD ANYTHING ELSE AFTER THIS!

--- a/bazel/go/deps.bzl
+++ b/bazel/go/deps.bzl
@@ -103,8 +103,8 @@ def fetch_go_deps():
     go_repository(
         name = "com_github_stretchr_testify",
         importpath = "github.com/stretchr/testify",
-        sum = "h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=",
-        version = "v1.5.1",
+        sum = "h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=",
+        version = "v1.7.0",
     )
     go_repository(
         name = "com_google_cloud_go",
@@ -124,6 +124,13 @@ def fetch_go_deps():
         sum = "h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=",
         version = "v2.2.2",
     )
+    go_repository(
+        name = "in_gopkg_yaml_v3",
+        importpath = "gopkg.in/yaml.v3",
+        sum = "h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=",
+        version = "v3.0.0-20200313102051-9f266ea9e77c",
+    )
+
     go_repository(
         name = "org_golang_google_appengine",
         importpath = "google.golang.org/appengine",

--- a/bazel/patches/gazelle.patch
+++ b/bazel/patches/gazelle.patch
@@ -1,0 +1,13 @@
+diff --git a/internal/gazelle.bash.in b/internal/gazelle.bash.in
+--- a/internal/gazelle.bash.in
++++ b/internal/gazelle.bash.in
+@@ -45,6 +45,9 @@ function find_runfile {
+ # use the SDK used by the workspace in case the Go SDK is not installed
+ # on the host system or is a different version.
+ function set_goroot {
++  # when --no_legacy_external_runfiles is set, gazelle cannot find GOROOT.
++  # Replace 'external' with '../' solves this.
++  GOTOOL=${GOTOOL/#external/..}
+   local gotool=$(find_runfile "$GOTOOL")
+   if [ -z "$gotool" ]; then
+     echo "$0: warning: could not locate GOROOT used by rules_go" >&2

--- a/bazel/workspace_deps.bzl
+++ b/bazel/workspace_deps.bzl
@@ -23,6 +23,8 @@ def fetch_deps():
     http_archive(
         name = "bazel_gazelle",
         sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+        patch_args = ["-p1"],
+        patches = ["//bazel/patches:gazelle.patch"],
         urls = [
             "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
             "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
@@ -42,7 +44,6 @@ def fetch_deps():
     http_archive(
         name = "com_github_grpc_grpc",
         urls = [
-            "https://mirror.bazel.build/github.com/grpc/grpc/archive/3e53dbe8213137d2c731ecd4d88ebd2948941d75.tar.gz",
             "https://github.com/grpc/grpc/archive/3e53dbe8213137d2c731ecd4d88ebd2948941d75.tar.gz",
         ],
         sha256 = "89bab58f7bd36f2826b0bde92ea5668324642fe281d636dd18025354586cb764",

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/google/uuid v1.2.0 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c // indirect
 	golang.org/x/text v0.3.6 // indirect
 	google.golang.org/grpc v1.36.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4 h1:c2HOrn5iMezYjSlGPncknSEr/8x5LELb/ilJbXi9DEA=
@@ -116,6 +118,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc h1:/hemPrYIhOhy8zYrNj+069zDB68us2sMGsfkFJO0iZs=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/utils-go/stackerrors/BUILD.bazel
+++ b/utils-go/stackerrors/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "stackerrors",
+    srcs = [
+        "doc.go",
+        "errors.go",
+        "stacktrace.go",
+    ],
+    importpath = "github.com/TerrenceHo/monorepo/utils-go/stackerrors",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "stackerrors_test",
+    size = "small",
+    srcs = [
+        "errors_test.go",
+        "stacktrace_test.go",
+    ],
+    embed = [":stackerrors"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/utils-go/stackerrors/doc.go
+++ b/utils-go/stackerrors/doc.go
@@ -1,0 +1,15 @@
+/*
+Package stackerrors provides simple error handling, on top of the stdlib's
+implementation of error handling.
+
+Context can be added to an error: instead of just
+
+ 	if err != nil {
+ 			return nil
+ 	}
+
+We can wrap the original error with context of when this error was received
+before passing the error up the chain.
+*/
+
+package stackerrors

--- a/utils-go/stackerrors/errors.go
+++ b/utils-go/stackerrors/errors.go
@@ -1,0 +1,173 @@
+package stackerrors
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// New creates a new error with a context and a stack trace. Returns a
+// contextError pointer.
+func New(ctx string) error {
+	return &contextError{
+		err:        nil,
+		ctx:        ctx,
+		stacktrace: getStackTrace(),
+	}
+}
+
+// Errorf is a convenience function mimics fmt.Errorf, but returns a
+// contextError with a stack trace too.
+func Errorf(format string, args ...interface{}) error {
+	return &contextError{
+		err:        nil,
+		ctx:        fmt.Sprintf(format, args...),
+		stacktrace: getStackTrace(),
+	}
+}
+
+// contextError implements the error interface. It contains an error, context
+// string, and a stack trace.
+type contextError struct {
+	err error
+	ctx string
+	*stacktrace
+}
+
+// Error allows ContextError to implement the error interface.
+func (e *contextError) Error() string {
+	if e.err != nil {
+		return fmt.Sprintf("%v: %s", e.ctx, e.err.Error())
+	}
+	return e.ctx
+}
+
+// As implements the As interface as specified in the errors library.
+// See https://golang.org/pkg/errors/#As
+// TODO(terrenceho): Figure out what functionality we actually want from As().
+func (e *contextError) As(target interface{}) bool {
+	_, ok := target.(*contextError)
+	if !ok {
+		return false
+	}
+	target = e
+	return true
+}
+
+// Is implements the Is interface as specified in the errors library.
+// See https://golang.org/pkg/errors/#Is
+func (e *contextError) Is(target error) bool {
+	c_target, ok := target.(*contextError)
+	if ok && e.err != nil && c_target.err != nil {
+		return e.ctx == c_target.ctx && e.err.Error() == c_target.err.Error()
+	}
+	return target.Error() == e.Error()
+}
+
+// Unwrap implements stderror's Unwrap function. Returns the previous error
+// without context.
+// See https://golang.org/pkg/errors/#Unwrap
+func (e *contextError) Unwrap() error {
+	return e.err
+}
+
+// Wrap is a convenience function around Wrapf
+func Wrap(err error, context string) error {
+	return &contextError{
+		err:        err,
+		ctx:        context,
+		stacktrace: getStackTrace(),
+	}
+}
+
+// Wrapf takes in an error, a string with optional formatting options, and
+// returns an error that wraps the input error. The returned error can be
+// unwrapped using the errors.Unwrap() method.
+//
+// Under the hood, Wrapf returns a ContextError that stores both the original
+// error and the formatted string.
+func Wrapf(err error, format string, args ...interface{}) error {
+	return &contextError{
+		err:        err,
+		ctx:        fmt.Sprintf(format, args...),
+		stacktrace: getStackTrace(),
+	}
+}
+
+// RootCause returns the root error that caused the chain or errors to being
+// with. It repeatedly tries to unwrap the error until it can no longer be
+// unwrapped.
+func RootCause(err error) error {
+	for {
+		ctx_err, ok := err.(*contextError)
+		if !ok {
+			return err
+		}
+		if ctx_err.err == nil {
+			return New(ctx_err.ctx)
+		}
+		err = ctx_err.err
+	}
+}
+
+///// formatting for contextError
+
+// Format implements the Formatter interface. It supports the following 3 verbs.
+//
+//		%s	print the error. If it is a contextError, the Error() implementation
+//			will cause the error to print recursively down the chain.
+//		%v	same as %s.
+//		%q  prints the error but in quotes, according to go's verb usage.
+//
+// The %v also has another option: %+v. This will print the stacktrace in the
+// following format
+//
+//		error message 3
+//		--- /path/github.com/repo/package/main.go:<line num> (FuncName)
+//		error message 2
+//		--- /path/github.com/repo/package/main.go:<line num> (Class.FuncName)
+//		error message 1
+//		--- /path/github.com/repo/package/main.go:<line num> ((*Class).FuncName)
+//
+// All other formating cases will fall through.
+func (ctx *contextError) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			msg := ctx.fullStackTrace("", s, verb)
+			fmt.Fprintf(s, "%s", msg)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, ctx.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", ctx.Error())
+	}
+}
+
+// recursively builds stack trace and returns the full formatted string.
+func (ctx *contextError) fullStackTrace(msg string, s fmt.State, verb rune) string {
+	msg = addNewline(msg)
+	msg += fmt.Sprint(ctx.ctx)
+	msg = addNewline(msg)
+	msg += fmt.Sprintf("%+v", ctx.stacktrace)
+	msg = addNewline(msg)
+
+	// recursively call format to print stack trace.
+	if ctx.err != nil {
+		f_ctx, ok := (ctx.err).(*contextError)
+		if ok {
+			msg += fmt.Sprintf("%+v", f_ctx)
+		}
+	}
+	return msg
+}
+
+// addNewLine adds a new line if it doesn't end in a newline or is not empty
+func addNewline(msg string) string {
+	if msg != "" && !strings.HasSuffix(msg, "\n") {
+		msg += "\n"
+	}
+	return msg
+}

--- a/utils-go/stackerrors/errors_test.go
+++ b/utils-go/stackerrors/errors_test.go
@@ -1,0 +1,489 @@
+package stackerrors
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	assert := assert.New(t)
+
+	type testcase struct {
+		err_ctx string
+	}
+
+	testcases := []testcase{
+		{err_ctx: "new error context"},
+		{err_ctx: "second error context"},
+	}
+
+	for _, testcase := range testcases {
+		e := New(testcase.err_ctx)
+		assert.EqualErrorf(e, testcase.err_ctx, "New error %w != %s", e, testcase.err_ctx)
+	}
+}
+
+func TestErrorf(t *testing.T) {
+	assert := assert.New(t)
+
+	type testcase struct {
+		format string
+		args   []interface{}
+		want   string
+	}
+
+	testcases := []testcase{
+		{
+			format: "%s %s",
+			args: []interface{}{
+				"error", "string",
+			},
+			want: "error string",
+		},
+		{
+			format: "%v errors in %s",
+			args: []interface{}{
+				5, "package",
+			},
+			want: "5 errors in package",
+		},
+	}
+
+	for _, testcase := range testcases {
+		e := Errorf(testcase.format, testcase.args...)
+		assert.EqualErrorf(
+			e, testcase.want, "Errorf error %v != %s", e, testcase.want,
+		)
+	}
+}
+
+func TestWrap(t *testing.T) {
+	assert := assert.New(t)
+
+	type testcase struct {
+		err    error
+		format string
+		want   string
+	}
+
+	testcases := []testcase{
+		{
+			err:    New("base error"),
+			format: "read error",
+			want:   "read error: base error",
+		},
+		{
+			err:    Wrap(New("base error"), "second error"),
+			format: "third error",
+			want:   "third error: second error: base error",
+		},
+		{
+			err:    errors.New("std error"),
+			format: "wrapper error",
+			want:   "wrapper error: std error",
+		},
+	}
+
+	for _, testcase := range testcases {
+		e := Wrap(testcase.err, testcase.format)
+		assert.EqualErrorf(
+			e, testcase.want, "Wrap error %v != %s", e, testcase.want,
+		)
+	}
+}
+
+func TestWrapf(t *testing.T) {
+	assert := assert.New(t)
+
+	type testcase struct {
+		err    error
+		format string
+		args   []interface{}
+		want   string
+	}
+
+	testcases := []testcase{
+		{
+			err:    New("base error"),
+			format: "%s number %d",
+			args: []interface{}{
+				"error", 2,
+			},
+			want: "error number 2: base error",
+		},
+		{
+			err:    Wrap(New("base error"), "second error"),
+			format: "error layer %d",
+			args: []interface{}{
+				3,
+			},
+			want: "error layer 3: second error: base error",
+		},
+		{
+			err:    errors.New("std error"),
+			format: "wrapper error",
+			args:   []interface{}{},
+			want:   "wrapper error: std error",
+		},
+	}
+
+	for _, testcase := range testcases {
+		e := Wrapf(testcase.err, testcase.format, testcase.args...)
+		assert.EqualErrorf(
+			e, testcase.want, "Wrap error %v != %s", e, testcase.want,
+		)
+	}
+}
+
+func TestIs(t *testing.T) {
+	assert := assert.New(t)
+
+	type testcase struct {
+		err    error
+		target error
+		want   bool
+	}
+
+	testcases := []testcase{
+		{
+			err:    New("error"),
+			target: New("error"),
+			want:   true,
+		},
+		{
+			err:    New("error"),
+			target: errors.New("error"),
+			want:   true,
+		},
+		{
+			err:    Wrap(New("error"), "second error"),
+			target: Wrap(New("error"), "second error"),
+			want:   true,
+		},
+		{
+			err:    Wrap(New("error"), "second error"),
+			target: New("error"),
+			want:   true,
+		},
+		{
+			err:    New("error"),
+			target: Wrap(New("error"), "second error"),
+			want:   false,
+		},
+		{
+			err:    Wrap(Wrap(New("error"), "error"), "error"),
+			target: New("error"),
+			want:   true,
+		},
+		{
+			err:    Wrap(Wrap(New("error"), "error"), "error"),
+			target: Wrap(New("error"), "error"),
+			want:   true,
+		},
+	}
+
+	for _, testcase := range testcases {
+		isEqual := errors.Is(testcase.err, testcase.target)
+
+		assert.Equalf(
+			isEqual,
+			testcase.want,
+			"errors.Is did not succeed: %b != %b for error %v and error %v",
+			isEqual,
+			testcase.want,
+			testcase.err,
+			testcase.target,
+		)
+	}
+}
+
+func TestAs(t *testing.T) {
+	assert := assert.New(t)
+	type testcase struct {
+		input     error
+		want_bool bool
+		want_err  error
+	}
+
+	testcases := []testcase{
+		{
+			input:     New("base error"),
+			want_bool: true,
+			want_err:  New("base error"),
+		},
+		{
+			input:     Wrapf(New("base error"), "second layer"),
+			want_bool: true,
+			want_err:  Wrapf(New("base error"), "second layer"),
+		},
+		{
+			input:     fmt.Errorf("fmt base error"),
+			want_bool: false,
+			want_err:  nil,
+		},
+	}
+
+	var ce *contextError
+	for _, testcase := range testcases {
+		b := errors.As(testcase.input, &ce)
+		if b {
+			assert.EqualErrorf(
+				ce, testcase.want_err.Error(),
+				"(As) %s != %s", ce, testcase.want_err.Error(),
+			)
+		} else {
+			assert.False(testcase.want_bool)
+		}
+	}
+}
+
+func TestUnwrap(t *testing.T) {
+	assert := assert.New(t)
+
+	type testcase struct {
+		input error
+		want  error
+	}
+
+	testcases := []testcase{
+		{
+			input: nil,
+			want:  nil,
+		},
+		{
+			input: New("no unwrap error"),
+			want:  nil,
+		},
+		{
+			input: Wrap(New("base error"), "second layer"),
+			want:  New("base error"),
+		},
+		{
+			input: Wrap(Wrap(New("base error"), "second layer"), "third layer"),
+			want:  Wrap(New("base error"), "second layer"),
+		},
+	}
+
+	for _, testcase := range testcases {
+		e := errors.Unwrap(testcase.input)
+		if e == nil {
+			assert.Nil(testcase.want)
+		} else {
+			assert.EqualErrorf(
+				e,
+				testcase.want.Error(),
+				"TestUnwrap: %s != %s",
+				testcase.input.Error(),
+				testcase.want.Error(),
+			)
+		}
+	}
+}
+
+func TestRootCause(t *testing.T) {
+	assert := assert.New(t)
+
+	type testcase struct {
+		input error
+		want  error
+	}
+
+	testcases := []testcase{
+		{
+			input: nil,
+			want:  nil,
+		},
+		{
+			input: New("base error"),
+			want:  New("base error"),
+		},
+		{
+			input: fmt.Errorf("new error"),
+			want:  fmt.Errorf("new error"),
+		},
+		{
+			input: Wrap(Wrap(New("base error"), "level 2"), "level 3"),
+			want:  New("base error"),
+		},
+		{
+			input: Wrap(&contextError{
+				ctx: "context",
+				err: nil,
+			}, "second layer"),
+			want: New("context"),
+		},
+	}
+
+	for _, testcase := range testcases {
+		e := RootCause(testcase.input)
+		if e == nil {
+			assert.Nil(testcase.want)
+		} else {
+			assert.EqualErrorf(
+				e, testcase.want.Error(),
+				"(RootCause) %s != %s",
+				e.Error(), testcase.want.Error(),
+			)
+		}
+	}
+}
+
+func TestContextFormat(t *testing.T) {
+	assert := assert.New(t)
+
+	type testcase struct {
+		format string
+		err    error
+		want   string
+	}
+
+	testcases := []testcase{
+		{
+			format: "%v",
+			err:    New("base error"),
+			want:   "base error",
+		},
+		{
+			format: "%s",
+			err:    New("base error"),
+			want:   "base error",
+		},
+		{
+			format: "%q",
+			err:    New("base error"),
+			want:   "\"base error\"",
+		},
+		{
+			format: "%v",
+			err:    Wrap(New("base error"), "second layer"),
+			want:   "second layer: base error",
+		},
+		{
+			format: "%s",
+			err:    Wrap(New("base error"), "second layer"),
+			want:   "second layer: base error",
+		},
+		{
+			format: "%q",
+			err:    Wrap(New("base error"), "second layer"),
+			want:   "\"second layer: base error\"",
+		},
+		{
+			format: "%v",
+			err:    Wrap(Wrap(New("base error"), "second layer"), "third layer"),
+			want:   "third layer: second layer: base error",
+		},
+		{
+			format: "%s",
+			err:    Wrap(Wrap(New("base error"), "second layer"), "third layer"),
+			want:   "third layer: second layer: base error",
+		},
+		{
+			format: "%q",
+			err:    Wrap(Wrap(New("base error"), "second layer"), "third layer"),
+			want:   "\"third layer: second layer: base error\"",
+		},
+	}
+
+	for _, testcase := range testcases {
+		s := fmt.Sprintf(testcase.format, testcase.err)
+		assert.Equalf(
+			testcase.want, s, "(ContextFormat) %s != %s", testcase.want,
+		)
+	}
+}
+
+func TestFormatStackTrace(t *testing.T) {
+	assert := assert.New(t)
+
+	type wantedTrace struct {
+		msg      string
+		file     string
+		function string
+	}
+	type testcase struct {
+		format string
+		err    error
+		want   []wantedTrace
+	}
+
+	err1 := New("base error")
+	err2 := Wrap(err1, "second layer")
+	err3 := Wrap(err2, "third layer")
+
+	testcases := []testcase{
+		{
+			format: "%+v",
+			err:    err1,
+			want: []wantedTrace{
+				{
+					msg:      "base error",
+					file:     "utils-go/stackerrors/errors_test.go",
+					function: "TestFormatStackTrace",
+				},
+			},
+		},
+		{
+			format: "%+v",
+			err:    err2,
+			want: []wantedTrace{
+				{
+					msg:      "second layer",
+					file:     "utils-go/stackerrors/errors_test.go",
+					function: "TestFormatStackTrace",
+				},
+				{
+					msg:      "base error",
+					file:     "utils-go/stackerrors/errors_test.go",
+					function: "TestFormatStackTrace",
+				},
+			},
+		},
+		{
+			format: "%+v",
+			err:    err3,
+			want: []wantedTrace{
+				{
+					msg:      "third layer",
+					file:     "utils-go/stackerrors/errors_test.go",
+					function: "TestFormatStackTrace",
+				},
+				{
+					msg:      "second layer",
+					file:     "utils-go/stackerrors/errors_test.go",
+					function: "TestFormatStackTrace",
+				},
+				{
+					msg:      "base error",
+					file:     "utils-go/stackerrors/errors_test.go",
+					function: "TestFormatStackTrace",
+				},
+			},
+		},
+	}
+
+	for _, testcase := range testcases {
+		s := fmt.Sprintf(testcase.format, testcase.err)
+		t.Log(s)
+		msgs := strings.Split(s, "\n")
+		for i := range testcase.want {
+			wt := testcase.want[i]
+			assert.Equal(wt.msg, msgs[0])
+			assert.Truef(
+				strings.Contains(msgs[1], wt.file),
+				"(file) %s does not contain %s",
+				msgs[1], wt.file,
+			)
+			assert.Truef(
+				strings.Contains(msgs[1], wt.function),
+				"(file) %s does not contain %s",
+				msgs[1], wt.file,
+			)
+			msgs = msgs[2:]
+		}
+	}
+}

--- a/utils-go/stackerrors/stacktrace.go
+++ b/utils-go/stackerrors/stacktrace.go
@@ -1,0 +1,72 @@
+package stackerrors
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+type stacktrace struct {
+	file     string // File where the error originated
+	function string // function or method where the error originated
+	line     int    // line number where the error originated
+}
+
+func (st *stacktrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			msg := formatStackEntry(st)
+			fmt.Fprintf(s, msg)
+			return
+		}
+	}
+}
+
+func formatStackEntry(st *stacktrace) string {
+	var msg string
+	msg = fmt.Sprintf("--- %s:%d (%s) ---", st.file, st.line, st.function)
+	return msg
+}
+
+// getStackTrace returns a stacktrace of the function that created the error.
+func getStackTrace() *stacktrace {
+	// getStackTrace is called from Wrapf(), New(), or Errorf(), so two levels
+	// above the caller will be the function that created the error
+	pc, file, line, ok := runtime.Caller(2)
+	if !ok {
+		// Debug symbols may have been stripped from the binary, so
+		// runtime.Caller may fail to return anything.
+		return nil
+	}
+	funcName := funcFromPC(pc)
+
+	st := stacktrace{
+		file:     file,
+		line:     line,
+		function: funcName,
+	}
+
+	return &st
+}
+
+// funcFromPC takes in a pc counter and returns the function name without a path
+// as a string. There are three possible types of function paths:
+// - github.com/org/path/package.FuncName (Function)
+// - github.com/org/path/package.Class.FuncName (Method)
+// - github.com/org/path/package.(*Class).FuncName (Pointer Method)
+func funcFromPC(pc uintptr) string {
+	f := runtime.FuncForPC(pc)
+	funcName := f.Name()
+	return processFuncName(funcName)
+}
+
+func processFuncName(funcName string) string {
+	// remove path parts by indexing to the last "/"
+	funcName = funcName[strings.LastIndex(funcName, "/")+1:]
+
+	// remove "package" name
+	funcName = funcName[strings.Index(funcName, ".")+1:]
+
+	return funcName
+}

--- a/utils-go/stackerrors/stacktrace_test.go
+++ b/utils-go/stackerrors/stacktrace_test.go
@@ -1,0 +1,203 @@
+package stackerrors
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessFuncName(t *testing.T) {
+	assert := assert.New(t)
+
+	type testcase struct {
+		input  string
+		wanted string
+	}
+
+	testcases := []testcase{
+		{
+			input:  "github.com/org/path/package.FuncName",
+			wanted: "FuncName",
+		},
+		{
+			input:  "github.com/org/path/package.Class.FuncName",
+			wanted: "Class.FuncName",
+		},
+		{
+			input:  "github.com/org/path/package.(*Class).FuncName",
+			wanted: "(*Class).FuncName",
+		},
+		{
+			input:  "FuncName",
+			wanted: "FuncName",
+		},
+		{
+			input:  "",
+			wanted: "",
+		},
+		{
+			input:  "main.FakeCaller",
+			wanted: "FakeCaller",
+		},
+	}
+
+	for _, testcase := range testcases {
+		s := processFuncName(testcase.input)
+		assert.Equalf(
+			s, testcase.wanted, "(processFuncName) %s != %s", s, testcase.wanted,
+		)
+	}
+}
+
+func TestFuncFromPC(t *testing.T) {
+	assert := assert.New(t)
+
+	wanted := []string{
+		"helpTestFunc",
+		"fakeStruct.helpTestMethod",
+		"(*fakeStruct).helpTestPointerMethod",
+	}
+
+	fs := fakeStruct{}
+	fsp := &fakeStruct{}
+
+	hTF := helpTestFunc()
+	assert.Equalf(wanted[0], hTF, "(TestFunc): %s != %s", wanted[0], hTF)
+	hTM := fs.helpTestMethod()
+	assert.Equalf(wanted[1], hTM, "(TestFunc): %s != %s", wanted[1], hTM)
+	hTPM := fsp.helpTestPointerMethod()
+	assert.Equalf(wanted[2], hTPM, "(TestFunc): %s != %s", wanted[2], hTPM)
+}
+
+func TestGetStackTrace(t *testing.T) {
+	assert := assert.New(t)
+
+	type testcase struct {
+		which    string
+		function string
+	}
+
+	testcases := []testcase{
+		{
+			which:    "function",
+			function: "fakeFunction",
+		},
+		{
+			which:    "method",
+			function: "stackTraceFake.fakeMethod",
+		},
+		{
+			which:    "pointer-method",
+			function: "(*stackTraceFake).fakePointerMethod",
+		},
+	}
+
+	for _, testcase := range testcases {
+		var st *stacktrace
+		switch s := testcase.which; s {
+		case "function":
+			st = fakeFunction()
+		case "method":
+			st = stackTraceFake{}.fakeMethod()
+		case "pointer-method":
+			st = (&stackTraceFake{}).fakePointerMethod()
+		default:
+			assert.Fail("Testcase not found")
+		}
+		assert.Equalf(
+			testcase.function, st.function,
+			"(getStackTrace) %s != %s",
+			testcase.function, st.function,
+		)
+		assert.Greaterf(st.line, 0, "(getStackTrace) %d <= %d", st.line, 0)
+		assert.NotEmpty(st.file, "(getStackTrace) file was empty")
+	}
+}
+
+func TestStacktraceFormat(t *testing.T) {
+	assert := assert.New(t)
+	type testcase struct {
+		format string
+		st     *stacktrace
+		want   string
+	}
+
+	testcases := []testcase{
+		{
+			format: "%+v",
+			st: &stacktrace{
+				file:     "file/path.go",
+				function: "funcName",
+				line:     32,
+			},
+			want: "--- file/path.go:32 (funcName) ---",
+		},
+		{
+			format: "string %+v more string",
+			st: &stacktrace{
+				file:     "file/path.go",
+				function: "funcName",
+				line:     32,
+			},
+			want: "string --- file/path.go:32 (funcName) --- more string",
+		},
+		{
+			format: "string %v more string",
+			st: &stacktrace{
+				file:     "file/path.go",
+				function: "funcName",
+				line:     32,
+			},
+			want: "string  more string",
+		},
+	}
+
+	for _, testcase := range testcases {
+		s := fmt.Sprintf(testcase.format, testcase.st)
+		assert.Equalf(testcase.want, s, "%s != %s", testcase.want, s)
+	}
+}
+
+///// Helper test functions for TestFuncFromPC
+func helpTestFunc() string {
+	return funcFromPC(getPC())
+}
+
+type fakeStruct struct{}
+
+func (f fakeStruct) helpTestMethod() string {
+	return funcFromPC(getPC())
+}
+
+func (f *fakeStruct) helpTestPointerMethod() string {
+	return funcFromPC(getPC())
+}
+
+func getPC() uintptr {
+	pc, _, _, ok := runtime.Caller(1)
+	if !ok {
+		return 0
+	}
+	return pc
+}
+
+///// Helper test functions for TestGetStackTrace
+func fakeErrorCaller() *stacktrace {
+	return getStackTrace()
+}
+
+type stackTraceFake struct{}
+
+func fakeFunction() *stacktrace {
+	return fakeErrorCaller()
+}
+
+func (stf stackTraceFake) fakeMethod() *stacktrace {
+	return fakeErrorCaller()
+}
+
+func (stf *stackTraceFake) fakePointerMethod() *stacktrace {
+	return fakeErrorCaller()
+}


### PR DESCRIPTION
**Summary**
Create go error package that satisfies the interface of the stdlib error
functions (`Is()`, `As()`, `Unwrap()`) and create some Wrapper functions
to wrap errors that pop up.

Also added .bazelrc to configure bazel options.


**Test Plan**
`bazel test //...`

**Issue(s)**
N/A
