### PR TITLE
[autofresh] Add recursive watcher

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,9 +14,9 @@ jobs:
           cache-name: bazel-cache
         with:
           path: |
-            ~/.cache/bazelisk  # cache bazel binary
-            ~/.cache/bazel     # cache bazel outputs and test runs
-          key: bazel-${{ runner.os }}-${{ env.cache-name }}
+            ~/.cache/bazelisk          # cache bazel binary
+            ~/.cache/bazel-disk-cache  # cache bazel outputs and test runs
+          key: bazel-${{ runner.os }}-${{ env.cache-name }}-v0.1.0
 
 
       # Checks-out your repository under $GITHUB_WORKSPACE, which is the CWD for

--- a/autofresh/BUILD
+++ b/autofresh/BUILD
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "autofresh",
+    srcs = [
+        "app.go",
+        "logger.go",
+    ],
+    importpath = "github.com/TerrenceHo/monorepo/autofresh",
+    visibility = ["//visibility:public"],
+)

--- a/autofresh/app.go
+++ b/autofresh/app.go
@@ -1,0 +1,1 @@
+package autofresh

--- a/autofresh/cmd/autofresh/BUILD
+++ b/autofresh/cmd/autofresh/BUILD
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "autofresh_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/TerrenceHo/monorepo/autofresh/cmd/autofresh",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "autofresh",
+    embed = [":autofresh_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/autofresh/cmd/autofresh/main.go
+++ b/autofresh/cmd/autofresh/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello autofresh!")
+}

--- a/autofresh/logger.go
+++ b/autofresh/logger.go
@@ -1,0 +1,1 @@
+package autofresh

--- a/autofresh/watcher/BUILD
+++ b/autofresh/watcher/BUILD
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "watcher",
+    srcs = ["recursive_watcher.go"],
+    importpath = "github.com/TerrenceHo/monorepo/autofresh/watcher",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//utils-go/stackerrors",
+        "@com_github_fsnotify_fsnotify//:fsnotify",
+    ],
+)
+
+go_test(
+    name = "watcher_test",
+    size = "small",
+    srcs = ["recursive_watcher_test.go"],
+    embed = [":watcher"],
+    deps = [
+        "@com_github_fsnotify_fsnotify//:fsnotify",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/autofresh/watcher/recursive_watcher.go
+++ b/autofresh/watcher/recursive_watcher.go
@@ -1,0 +1,154 @@
+package watcher
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/TerrenceHo/monorepo/utils-go/stackerrors"
+	"github.com/fsnotify/fsnotify"
+)
+
+type RecursiveWatcherClosedError struct{}
+
+func (e RecursiveWatcherClosedError) Error() string {
+	return "RecursiveWatcher has already been closed"
+}
+
+type RecursiveWatcher struct {
+	watcher  *fsnotify.Watcher
+	Events   chan fsnotify.Event
+	Errors   chan error
+	stop     chan bool
+	isClosed bool
+}
+
+func New() (*RecursiveWatcher, error) {
+	watcher, err := fsnotify.NewWatcher()
+
+	if err != nil {
+		stackerrors.Wrap(err, "fsnotify watcher could not be created")
+	}
+
+	rWatcher := &RecursiveWatcher{
+		watcher:  watcher,
+		Events:   make(chan fsnotify.Event),
+		Errors:   make(chan error),
+		stop:     make(chan bool),
+		isClosed: false,
+	}
+	go rWatcher.run()
+	return rWatcher, nil
+}
+
+func (rw *RecursiveWatcher) Add(path string) error {
+	if rw.isClosed {
+		return stackerrors.Wrap(
+			RecursiveWatcherClosedError{}, "Add failed",
+		)
+	}
+	return rw.watcher.Add(path)
+}
+
+func (rw *RecursiveWatcher) AddRecursive(path string) error {
+	if rw.isClosed {
+		return stackerrors.Wrap(
+			RecursiveWatcherClosedError{}, "AddRecursive failed",
+		)
+	}
+	if err := rw.walkdir(path, true); err != nil {
+		return stackerrors.Wrap(err, "Add Recursive walkdir failed")
+	}
+	return nil
+}
+
+func (rw *RecursiveWatcher) Remove(path string) error {
+	if rw.isClosed {
+		return stackerrors.Wrap(
+			RecursiveWatcherClosedError{}, "Remove failed",
+		)
+	}
+	return rw.watcher.Remove(path)
+}
+
+func (rw *RecursiveWatcher) RemoveRecursive(path string) error {
+	if rw.isClosed {
+		return stackerrors.Wrap(
+			RecursiveWatcherClosedError{}, "RemoveRecursive failed",
+		)
+	}
+	if err := rw.walkdir(path, false); err != nil {
+		return stackerrors.Wrap(err, "RemoveRecursive walkdir failed")
+	}
+	return nil
+}
+
+func (rw *RecursiveWatcher) Close() error {
+	if rw.isClosed {
+		return nil
+	}
+	close(rw.stop)
+	rw.isClosed = true
+	return nil
+}
+
+func (rw *RecursiveWatcher) run() {
+	for {
+		select {
+		case event, ok := <-rw.watcher.Events:
+			if !ok {
+				return
+			}
+			stats, err := os.Stat(event.Name)
+			if err == nil && stats != nil && stats.IsDir() &&
+				event.Op&fsnotify.Create != 0 {
+				rw.walkdir(event.Name, true)
+			}
+
+			if event.Op&fsnotify.Remove != 0 {
+				rw.watcher.Remove(event.Name)
+			}
+
+			rw.Events <- event
+		case err, ok := <-rw.watcher.Errors:
+			if !ok {
+				return
+			}
+			rw.Errors <- err
+		case <-rw.stop:
+			rw.watcher.Close()
+			close(rw.Events)
+			close(rw.Errors)
+			return
+		}
+	}
+}
+
+func (rw *RecursiveWatcher) walkdir(rootpath string, isAdd bool) error {
+	walkfunc := func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return stackerrors.Wrap(err, "walkdir-walkfunc failed")
+		}
+		if d.IsDir() {
+			if isAdd {
+				if err := rw.watcher.Add(path); err != nil {
+					return stackerrors.Wrapf(
+						err, "walkdir-walkfunc Add path %s failed", path,
+					)
+				}
+			} else {
+				if err := rw.watcher.Remove(path); err != nil {
+					return stackerrors.Wrapf(
+						err, "walkdir-walkfunc Remove path %s failed", path,
+					)
+				}
+			}
+		}
+		return nil
+	}
+
+	if err := filepath.WalkDir(rootpath, walkfunc); err != nil {
+		return stackerrors.Wrap(err, "walkdir failed")
+	}
+	return nil
+}

--- a/autofresh/watcher/recursive_watcher_test.go
+++ b/autofresh/watcher/recursive_watcher_test.go
@@ -1,0 +1,322 @@
+package watcher
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/stretchr/testify/assert"
+)
+
+// An atomic counter
+type counter struct {
+	val int32
+}
+
+func (c *counter) increment() {
+	atomic.AddInt32(&c.val, 1)
+}
+
+func (c *counter) value() int32 {
+	return atomic.LoadInt32(&c.val)
+}
+
+func (c *counter) reset() {
+	atomic.StoreInt32(&c.val, 0)
+}
+
+func renameFile(file, rename string) error {
+	switch runtime.GOOS {
+	case "windows", "plan9":
+		return os.Rename(file, rename)
+	default:
+		cmd := exec.Command("mv", file, rename)
+		return cmd.Run()
+	}
+}
+
+func tempFile(t *testing.T, dir string) string {
+	file, err := ioutil.TempFile(dir, "tempfile")
+	if err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+	defer file.Close()
+	return file.Name()
+}
+
+func tempDir(t *testing.T, dir string) string {
+	directory, err := ioutil.TempDir(dir, "tempdir")
+	if err != nil {
+		t.Fatalf("failed to create test directory: %v", err)
+	}
+	return directory
+}
+
+func newRecursiveWatcher(t *testing.T) *RecursiveWatcher {
+	rWatcher, err := New()
+	if err != nil {
+		t.Fatalf("newCursiveWatcher error: %v", err)
+	}
+	return rWatcher
+}
+
+func addRecursiveWatch(t *testing.T, watcher *RecursiveWatcher, dir string) {
+	if err := watcher.AddRecursive(dir); err != nil {
+		t.Fatalf("addRecursiveWatch err: %v", err)
+	}
+}
+
+func removeRecursiveWatch(t *testing.T, watcher *RecursiveWatcher, dir string) {
+	if err := watcher.RemoveRecursive(dir); err != nil {
+		t.Fatalf("addRecursiveWatch err: %v", err)
+	}
+}
+
+func TestRecursive(t *testing.T) {
+	assert := assert.New(t)
+	rWatcher := newRecursiveWatcher(t)
+	defer rWatcher.Close()
+
+	go func() {
+		for err := range rWatcher.Errors {
+			t.Fatalf("error received: %v", err)
+		}
+	}()
+
+	rootDir := t.TempDir()
+	addRecursiveWatch(t, rWatcher, rootDir)
+
+	var createCounter, writeCounter, removeCounter, renameCounter counter
+	done := make(chan bool)
+	go func() {
+		for event := range rWatcher.Events {
+			t.Logf("event received: %s", event)
+			if event.Op&fsnotify.Create == fsnotify.Create {
+				createCounter.increment()
+			}
+			if event.Op&fsnotify.Write == fsnotify.Write {
+				writeCounter.increment()
+			}
+			if event.Op&fsnotify.Remove == fsnotify.Remove {
+				removeCounter.increment()
+			}
+			if event.Op&fsnotify.Rename == fsnotify.Rename {
+				renameCounter.increment()
+			}
+		}
+		t.Log("event loop done")
+		done <- true
+	}()
+
+	// Create subdirectory
+	subdir := tempDir(t, rootDir)
+	t.Logf("rootdir: %s", rootDir)
+	t.Logf("subdir: %s", subdir)
+	testFile := filepath.Join(subdir, "TestRecursiveWatcher.testfile")
+	renamedFile := filepath.Join(subdir, "TestRecursiveWatcher.renamefile")
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Create a file in subdirectory
+	f, err := os.Create(testFile)
+	if err != nil {
+		t.Fatalf("Creating test file failed: %s", testFile)
+	}
+	f.Sync()
+	time.Sleep(50 * time.Millisecond)
+
+	// Write to file in subdirectory
+	f.WriteString("test data")
+	f.Sync()
+	time.Sleep(50 * time.Millisecond)
+
+	// Write to file a second time in subdirectory
+	f.WriteString("second write")
+	f.Sync()
+	f.Close()
+	time.Sleep(50 * time.Millisecond)
+
+	// Rename file in subdirectory
+	if err := os.Rename(testFile, renamedFile); err != nil {
+		t.Fatalf("rename failed: %s", renamedFile)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	// Write to renamed file
+	f, err = os.OpenFile(renamedFile, os.O_WRONLY, 0666)
+	if err != nil {
+		t.Fatalf("opening renamed file failed: %s", renamedFile)
+	}
+	if _, err := f.WriteString("renamed file writes"); err != nil {
+		t.Fatalf("writing to renamed file %q failed: %v", renamedFile, err)
+	}
+	f.Sync()
+	f.Close()
+	time.Sleep(50 * time.Millisecond)
+
+	// Delete renamed file
+	err = os.Remove(renamedFile)
+	if err != nil {
+		t.Fatalf("error removing renamed file: %s", renamedFile)
+	}
+
+	time.Sleep(500 * time.Millisecond) // wait for all events to catch up
+
+	assert.EqualValuesf(
+		3, createCounter.value(),
+		"got %d create events, wanted %d", createCounter.value(), 3,
+	)
+	assert.EqualValuesf(
+		3, writeCounter.value(),
+		"got %d write events, wanted %d", writeCounter.value(), 3,
+	)
+	assert.EqualValuesf(
+		1, removeCounter.value(),
+		"got %d remove events, wanted %d", removeCounter.value(), 1,
+	)
+	assert.EqualValuesf(
+		1, renameCounter.value(),
+		"got %d rename events, wanted %d", renameCounter.value(), 1,
+	)
+
+	t.Log("calling Close()")
+	rWatcher.Close()
+	t.Log("waiting for the event channel to become closed...")
+	select {
+	case <-done:
+		t.Log("Events channel closed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("event stream was not closed after 2 seconds")
+	}
+}
+
+func TestRecursiveRemove(t *testing.T) {
+	assert := assert.New(t)
+	rWatcher := newRecursiveWatcher(t)
+	defer rWatcher.Close()
+
+	go func() {
+		for err := range rWatcher.Errors {
+			t.Fatalf("error received: %v", err)
+		}
+	}()
+
+	rootDir := t.TempDir()
+	addRecursiveWatch(t, rWatcher, rootDir)
+
+	var createCounter, writeCounter, removeCounter, renameCounter counter
+	done := make(chan bool)
+	go func() {
+		for event := range rWatcher.Events {
+			t.Logf("event received: %s", event)
+			if event.Op&fsnotify.Create == fsnotify.Create {
+				createCounter.increment()
+			}
+			if event.Op&fsnotify.Write == fsnotify.Write {
+				writeCounter.increment()
+			}
+			if event.Op&fsnotify.Remove == fsnotify.Remove {
+				removeCounter.increment()
+			}
+			if event.Op&fsnotify.Rename == fsnotify.Rename {
+				renameCounter.increment()
+			}
+		}
+		t.Log("event loop done")
+		done <- true
+	}()
+
+	// Create subdirectory
+	subdir := tempDir(t, rootDir)
+	t.Logf("rootdir: %s", rootDir)
+	t.Logf("subdir: %s", subdir)
+	testFile1 := filepath.Join(subdir, "TestRemoveRecursiveWatcher.testfile")
+	testFile2 := filepath.Join(subdir, "TestRemoveRecursiveWatcher.fake")
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Create a file in subdirectory
+	f, err := os.Create(testFile1)
+	if err != nil {
+		t.Fatalf("Creating test file failed: %s", testFile1)
+	}
+	f.Sync()
+	time.Sleep(50 * time.Millisecond)
+
+	// Stop watching recursively
+	removeRecursiveWatch(t, rWatcher, rootDir)
+
+	// Create a file in subdirectory, should not be watched
+	f, err = os.Create(testFile2)
+	if err != nil {
+		t.Fatalf("Creating test file failed: %s", testFile1)
+	}
+	f.Sync()
+	time.Sleep(50 * time.Millisecond)
+
+	assert.EqualValuesf(
+		2, createCounter.value(),
+		"got %d create events, wanted %d", createCounter.value(), 2,
+	)
+	assert.EqualValuesf(
+		0, writeCounter.value(),
+		"got %d write events, wanted %d", writeCounter.value(), 0,
+	)
+	assert.EqualValuesf(
+		0, removeCounter.value(),
+		"got %d remove events, wanted %d", removeCounter.value(), 0,
+	)
+	assert.EqualValuesf(
+		0, renameCounter.value(),
+		"got %d rename events, wanted %d", renameCounter.value(), 0,
+	)
+
+	t.Log("calling Close()")
+	rWatcher.Close()
+	t.Log("waiting for the event channel to become closed...")
+	select {
+	case <-done:
+		t.Log("Events channel closed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("event stream was not closed after 2 seconds")
+	}
+}
+
+func TestIsClosed(t *testing.T) {
+	assert := assert.New(t)
+	rWatcher := newRecursiveWatcher(t)
+	if err := rWatcher.Close(); err != nil {
+		t.Fatal("Close did not succeed")
+	}
+
+	err := rWatcher.Add("/fake/path")
+	assert.EqualErrorf(
+		err, "Add failed: RecursiveWatcher has already been closed",
+		"%s != %s",
+		err.Error(), "Add failed: RecursiveWatcher has already been closed",
+	)
+	err = rWatcher.AddRecursive("/fake/path")
+	assert.EqualErrorf(
+		err, "AddRecursive failed: RecursiveWatcher has already been closed",
+		"%s != %s",
+		err.Error(), "AddRecursive failed: RecursiveWatcher has already been closed",
+	)
+	err = rWatcher.Remove("/fake/path")
+	assert.EqualErrorf(
+		err, "Remove failed: RecursiveWatcher has already been closed",
+		"%s != %s",
+		err.Error(), "Remove failed: RecursiveWatcher has already been closed",
+	)
+	err = rWatcher.RemoveRecursive("/fake/path")
+	assert.EqualErrorf(
+		err, "RemoveRecursive failed: RecursiveWatcher has already been closed",
+		"%s != %s",
+		err.Error(), "RemoveRecursive failed: RecursiveWatcher has already been closed",
+	)
+}

--- a/bazel/go/deps.bzl
+++ b/bazel/go/deps.bzl
@@ -51,6 +51,13 @@ def fetch_go_deps():
         version = "v0.1.0",
     )
     go_repository(
+        name = "com_github_fsnotify_fsnotify",
+        importpath = "github.com/fsnotify/fsnotify",
+        sum = "h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=",
+        version = "v1.4.9",
+    )
+
+    go_repository(
         name = "com_github_golang_glog",
         importpath = "github.com/golang/glog",
         sum = "h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=",

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/TerrenceHo/monorepo
 go 1.16
 
 require (
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad h1:E
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
@@ -73,6 +75,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44 h1:Bli41pIlzTzf3KEY06n+xnzK/BESIg2ze4Pgfh/aI8c=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
**Summary**
Start port of autofresh to monorepo by adding a recursive watcher that
recursively watches for changes in a directory and all of its
subdirectories. It wraps fsnotify, because fsnotify does not recursively
watch directories currently.

Tests are included; tests might be slightly flaky due to file system
dependencies. Solution is to bump up the sleep times to wait for
recursive watcher to catch up.

**Test Plan**
`bazel coverage //...`

**Issue(s)**
N/A
