### PR TITLE
[utils-go] Implement password hashing in argon2id

### DIFF
--- a/utils-go/hash/BUILD.bazel
+++ b/utils-go/hash/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "hash",
+    srcs = ["argon2id.go"],
+    importpath = "github.com/TerrenceHo/monorepo/utils-go/hash",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//utils-go/random",
+        "//utils-go/stackerrors",
+        "@org_golang_x_crypto//argon2",
+    ],
+)
+
+go_test(
+    name = "hash_test",
+    size = "small",
+    srcs = ["argon2id_test.go"],
+    embed = [":hash"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/utils-go/hash/argon2id.go
+++ b/utils-go/hash/argon2id.go
@@ -1,0 +1,143 @@
+package hash
+
+import (
+	"crypto/subtle"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/TerrenceHo/monorepo/utils-go/random"
+	"github.com/TerrenceHo/monorepo/utils-go/stackerrors"
+	"golang.org/x/crypto/argon2"
+)
+
+var (
+	ErrInvalidHash         = stackerrors.New("the encoded hash is not in the correct format")
+	ErrWrongHashAlgorithm  = stackerrors.New("the hashing algorithm is not correct")
+	ErrIncompatibleVersion = stackerrors.New("incompatible version of argon2")
+)
+
+// Argon2ID implements the Hasher interface. Underneath, it uses the Argon2ID
+// implementation to hash passwords and compare passwords.
+type Argon2ID struct {
+	memory      uint32 // memory in kibibytes, 64 * 1024 recommended
+	iterations  uint32 // number of passes, 3 recommended
+	parallelism uint8  // number of threads used by algorithm, 4 recommended
+	saltLength  uint32 // length of salt, 16 recommended
+	keyLength   uint32 // length of the generated hash, 16+ bytes recommended
+	version     int    // version of the argon2ID algorithm
+}
+
+func NewArgon2ID(memory, iterations uint32, parallelism uint8, saltLength, keyLength uint32) *Argon2ID {
+	return &Argon2ID{
+		memory:      memory,
+		iterations:  iterations,
+		parallelism: parallelism,
+		saltLength:  saltLength,
+		keyLength:   keyLength,
+		version:     argon2.Version,
+	}
+}
+
+// HashPassword takes in a password string and hashes + salts it using the
+// Argon2ID algorithm.  It is recommended that you pass in a password + pepper
+// combination, because the pepper should be a secret value that is not stored
+// alongside the hashed password.
+//
+// The password is stored in the following format:
+//		$argon2id$v={version}$m={memory},t={iterations},p={parallelism}${salt}${hash}
+func (a *Argon2ID) HashPassword(password string) (encodedHash string, err error) {
+	// Generate a cryptographically secure random salt.
+	salt, err := random.GenerateRandomBytes(a.saltLength)
+	if err != nil {
+		return "", err
+	}
+
+	// Pass the plaintext password, salt and parameters to the argon2.IDKey
+	// function. This will generate a hash of the password using the Argon2id
+	// variant.
+	hash := argon2.IDKey([]byte(password), salt, a.iterations, a.memory, a.parallelism, a.keyLength)
+
+	// Base64 encode the salt and hashed password.
+	b64Salt := base64.RawStdEncoding.EncodeToString(salt)
+	b64Hash := base64.RawStdEncoding.EncodeToString(hash)
+
+	// Return a string using the standard encoded hash representation.
+	encodedHash = fmt.Sprintf("$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version, a.memory, a.iterations, a.parallelism, b64Salt, b64Hash)
+
+	return encodedHash, nil
+}
+
+// ComparePasswordAndHash takes a password and the hash, and extracts the salt
+// and strength parameters, and compares the hashes in constant time (avoiding
+// time collision attacks).
+func (a *Argon2ID) ComparePasswordAndHash(password, encodedHash string) (match bool, err error) {
+	// Extract the parameters, salt and derived key from the encoded password
+	// hash.
+	salt, hash, err := a.decodeHash(encodedHash)
+	if err != nil {
+		return false, err
+	}
+
+	// Derive the key from the other password using the same parameters.
+	otherHash := argon2.IDKey([]byte(password), salt, a.iterations, a.memory, a.parallelism, a.keyLength)
+
+	// Check that the contents of the hashed passwords are identical. Note
+	// that we are using the subtle.ConstantTimeCompare() function for this
+	// to help prevent timing attacks.
+	if subtle.ConstantTimeCompare(hash, otherHash) == 1 {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (a *Argon2ID) decodeHash(encodedHash string) (salt, hash []byte, err error) {
+	vals := strings.Split(encodedHash, "$")
+	if len(vals) != 6 {
+		return nil, nil, ErrInvalidHash
+	}
+
+	if vals[1] != "argon2id" {
+		return nil, nil, ErrWrongHashAlgorithm
+	}
+
+	var version int
+	_, err = fmt.Sscanf(vals[2], "v=%d", &version)
+	if err != nil {
+		return nil, nil, err
+	}
+	if version != argon2.Version {
+		return nil, nil, ErrIncompatibleVersion
+	}
+
+	var memory, iterations uint32
+	var parallelism uint8
+	_, err = fmt.Sscanf(vals[3], "m=%d,t=%d,p=%d", &memory, &iterations, &parallelism)
+	if err != nil {
+		return nil, nil, err
+	}
+	if memory != a.memory || iterations != a.iterations || parallelism != a.parallelism {
+		return nil, nil, ErrInvalidHash
+	}
+
+	salt, err = base64.RawStdEncoding.DecodeString(vals[4])
+	if err != nil {
+		return nil, nil, err
+	}
+	saltLength := uint32(len(salt))
+	if saltLength != a.saltLength {
+		return nil, nil, ErrInvalidHash
+	}
+
+	hash, err = base64.RawStdEncoding.DecodeString(vals[5])
+	if err != nil {
+		return nil, nil, err
+	}
+	keyLength := uint32(len(hash))
+	if keyLength != a.keyLength {
+		return nil, nil, ErrInvalidHash
+	}
+
+	return salt, hash, nil
+}

--- a/utils-go/hash/argon2id_test.go
+++ b/utils-go/hash/argon2id_test.go
@@ -1,0 +1,150 @@
+package hash
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/argon2"
+)
+
+func TestArgon2IDHashPassword(t *testing.T) {
+	assert := assert.New(t)
+	password := "password" // the classical bad password
+	var memory uint32 = 64 * 1024
+	var iterations uint32 = 3
+	var parallelism uint8 = 4
+	var saltLength uint32 = 16
+	var keyLength uint32 = 32
+
+	a := NewArgon2ID(
+		memory, iterations, parallelism, saltLength, keyLength,
+	)
+
+	hash1, err := a.HashPassword(password)
+	hash2, err := a.HashPassword(password)
+	assert.Nil(err)
+	assert.NotEqualValues(hash1, password, "password should not equal hash1")
+	assert.NotEqualValues(hash2, password, "password should not equal hash2")
+	assert.NotEqualValues(hash1, hash2, "hash1 should not equal hash2")
+
+	decomposed := strings.Split(hash1, "$")
+	assert.Len(decomposed, 6, "decomposed hash should have six parts")
+	assert.EqualValues("", decomposed[0])
+	assert.EqualValues("argon2id", decomposed[1], "decomposed hash name not correct")
+	assert.EqualValues("v="+strconv.Itoa(argon2.Version), decomposed[2], "decomposed hash version not equal")
+	assert.EqualValuesf(
+		fmt.Sprintf("m=%d,t=%d,p=%d", memory, iterations, parallelism),
+		decomposed[3],
+		"%s != %s",
+		fmt.Sprintf("m=%d,t=%d,p=%d", memory, iterations, parallelism),
+		decomposed[3],
+	)
+	assert.NotEqualValues(password, decomposed[5], "decomposed hash password and hash should not be equal")
+}
+
+func getHash(
+	t *testing.T,
+	hashFunc func(password string) (string, error),
+	password string,
+) string {
+	assert := assert.New(t)
+	encodedHash, err := hashFunc(password)
+	assert.Nil(err)
+	return encodedHash
+}
+
+func TestArgon2IDComparePasswordAndHash(t *testing.T) {
+	assert := assert.New(t)
+	var memory uint32 = 64 * 1024
+	var iterations uint32 = 3
+	var parallelism uint8 = 4
+	var saltLength uint32 = 16
+	var keyLength uint32 = 32
+	a := NewArgon2ID(
+		memory, iterations, parallelism, saltLength, keyLength,
+	)
+
+	type testcase struct {
+		password string
+		hash     string
+		compare  bool
+		err      error
+	}
+
+	hash := getHash(t, a.HashPassword, "password")
+
+	testcases := []testcase{
+		{
+			password: "password",
+			hash:     hash,
+			compare:  true,
+			err:      nil,
+		},
+		{
+			password: "password",
+			hash:     "fake hash",
+			compare:  false,
+			err:      ErrInvalidHash,
+		},
+		{
+			password: "password",
+			hash:     strings.Replace(hash, "argon2id", "argon3id", 1),
+			compare:  false,
+			err:      ErrWrongHashAlgorithm,
+		},
+		{
+			password: "password",
+			hash:     strings.Replace(hash, "v="+strconv.Itoa(argon2.Version), "v=1", 1),
+			compare:  false,
+			err:      ErrIncompatibleVersion,
+		},
+		{
+			password: "password",
+			hash:     strings.Replace(hash, "m="+strconv.Itoa(int(memory)), "m=1", 1),
+			compare:  false,
+			err:      ErrInvalidHash,
+		},
+		{
+			password: "password",
+			hash:     strings.Replace(hash, "t="+strconv.Itoa(int(iterations)), "t=1", 1),
+			compare:  false,
+			err:      ErrInvalidHash,
+		},
+		{
+			password: "password",
+			hash:     strings.Replace(hash, "p="+strconv.Itoa(int(parallelism)), "p=1", 1),
+			compare:  false,
+			err:      ErrInvalidHash,
+		},
+		{
+			password: "password",
+			hash:     hash[:len(hash)-int(keyLength)-2] + hash[len(hash)-int(keyLength)-1:],
+			compare:  false,
+			err:      ErrInvalidHash,
+		},
+		{
+			password: "password",
+			hash:     hash[:len(hash)-1],
+			compare:  false,
+			err:      ErrInvalidHash,
+		},
+	}
+
+	for _, testcase := range testcases {
+		compare, err := a.ComparePasswordAndHash(testcase.password, testcase.hash)
+		assert.EqualValuesf(
+			testcase.compare,
+			compare,
+			"hash comparison not correct",
+		)
+		if testcase.err != nil {
+			assert.EqualError(testcase.err, err.Error())
+		} else {
+			assert.Nil(err)
+		}
+	}
+
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #23
* #21
* #20
* #19

hash contains an implmentation of the Argon2ID hashing and comparing protocol,
enabling passwords and other strings to be hashed/salted with a certain memory,
iteration, and parallelism requirement. Checking hashes is done in constant time
to avoid timing collision attacks.

Pull Request resolved: #22