### PR TITLE
utils hmac remember

### DIFF
--- a/utils-go/hmac/BUILD.bazel
+++ b/utils-go/hmac/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "hmac",
+    srcs = ["hmac.go"],
+    importpath = "github.com/TerrenceHo/monorepo/utils-go/hmac",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "hmac_test",
+    size = "small",
+    srcs = ["hmac_test.go"],
+    embed = [":hmac"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/utils-go/hmac/hmac.go
+++ b/utils-go/hmac/hmac.go
@@ -1,0 +1,28 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"hash"
+)
+
+type HMAC struct {
+	hmac hash.Hash
+}
+
+// NewHMAC returns a new HMAC object
+func NewHMAC(key string) HMAC {
+	return HMAC{
+		hmac: hmac.New(sha256.New, []byte(key)),
+	}
+}
+
+// Hash uses the internal hash to compute a sum and returns the base64 encoded
+// string.
+func (h HMAC) Hash(input string) string {
+	h.hmac.Reset()
+	h.hmac.Write([]byte(input))
+	b := h.hmac.Sum(nil)
+	return base64.URLEncoding.EncodeToString(b)
+}

--- a/utils-go/hmac/hmac_test.go
+++ b/utils-go/hmac/hmac_test.go
@@ -1,0 +1,22 @@
+package hmac
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	hashInput  = "input"
+	wrongInput = "wrong"
+)
+
+func TestHMAC(t *testing.T) {
+	assert := assert.New(t)
+	h := NewHMAC("key")
+	hash := h.Hash(hashInput)
+	wrongHash := h.Hash(wrongInput)
+	secondHash := h.Hash(hashInput)
+	assert.NotEqualValues(hash, wrongHash, "hashes should not have equal values")
+	assert.EqualValues(hash, secondHash, "hashes should have equal values")
+}

--- a/utils-go/remember/BUILD.bazel
+++ b/utils-go/remember/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "remember",
+    srcs = ["remember.go"],
+    importpath = "github.com/TerrenceHo/monorepo/utils-go/remember",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//utils-go/random",
+        "//utils-go/stackerrors",
+    ],
+)
+
+go_test(
+    name = "remember_test",
+    size = "small",
+    srcs = ["remember_test.go"],
+    embed = [":remember"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/utils-go/remember/remember.go
+++ b/utils-go/remember/remember.go
@@ -1,0 +1,20 @@
+package remember
+
+import (
+	"encoding/base64"
+
+	"github.com/TerrenceHo/monorepo/utils-go/random"
+	"github.com/TerrenceHo/monorepo/utils-go/stackerrors"
+)
+
+const RememberTokenByteCount = 32
+
+// RememberToken takes in a byteCount, and returns a random base64 encoded
+// string of bytes. Recommended to use at least 32 byteCount.
+func RememberToken(byteCount uint32) (string, error) {
+	b, err := random.GenerateRandomBytes(byteCount)
+	if err != nil {
+		return "", stackerrors.Wrap(err, "generating remember token failed")
+	}
+	return base64.URLEncoding.EncodeToString(b), nil
+}

--- a/utils-go/remember/remember_test.go
+++ b/utils-go/remember/remember_test.go
@@ -1,0 +1,29 @@
+package remember
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemember(t *testing.T) {
+	assert := assert.New(t)
+	token, err := RememberToken(RememberTokenByteCount)
+	assert.Nil(err, "Generating remember tokens should not error")
+	count, err := countBytes(token)
+	assert.Nil(err, "token is not base64 encoded")
+	assert.EqualValues(
+		RememberTokenByteCount,
+		count,
+		"remember token count length not equal to expected length",
+	)
+}
+
+func countBytes(b64str string) (int, error) {
+	b, err := base64.URLEncoding.DecodeString(b64str)
+	if err != nil {
+		return -1, err
+	}
+	return len(b), nil
+}


### PR DESCRIPTION

**Summary**
- [utils-go] Add hmac package
- [utils-go] Add remember package

Add HMAC type that computes HMACs for strings, useful for web servers.

Remember tokens are base64 encoded strings, useful for cookie
management.

**Test Plan**
`bazel test //...`

**Issue(s)**
N/A
