### PR TITLE
[WORKSPACE] Update to go 1.17

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,7 +17,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.16.3")
+go_register_toolchains(version = "1.17")
 
 load("@io_bazel_rules_go//extras:embed_data_deps.bzl", "go_embed_data_dependencies")
 


### PR DESCRIPTION
**Summary**
Update go version in WORKSPACE to 1.17

**Test Plan**
`bazel test //...` and `bazel build //...`

**Issue(s)**
N/A
