### PR TITLE
[bazel] Update image digest for static debug image

### DIFF
--- a/bazel/containers/images.bzl
+++ b/bazel/containers/images.bzl
@@ -14,6 +14,7 @@ def fetch_images():
         registry = "gcr.io",
         repository = "distroless/static-debian10",
         tag = "debug",
+        digest = "sha256:29a7c9bd164728e83937518f7e339a51ae096292ba6410cc2bcc07c4e99533f8",
     )
 
     container_pull(


### PR DESCRIPTION
**Summary**
Bazel reporting that the image requires a static digest tag

**Test Plan**
`bazel test //...`

**Issue(s)**
