### PR TITLE
Use new cache to always cache bazel hits

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,7 +5,7 @@
 # Tell bazel to store all symlinks it creates .bazel/
 build --symlink_prefix=.bazel/
 
-# Cache action outputs on local disk so they persist across output_bae and bazel
+# Cache action outputs on local disk so they persist across output_base and bazel
 # shutdown (helps with cache thrashing when changing branches).
 build --disk_cache=~/.cache/bazel-disk-cache
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,29 +1,34 @@
 name: CI
 
-on: [push, pull_request]
+on: 
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
 jobs:
   test:
     # virtual environments: https://github.com/actions/virtual-environments
     runs-on: ubuntu-20.04
 
     steps:
-      # Caches and restores bazelisk download directory, the bazel build directory.
-      - name: Cache bazel
-        uses: actions/cache@v2.1.7
-        env:
-          cache-name: bazel-cache
-        with:
-          path: |
-            ~/.cache/bazelisk          # cache bazel binary
-            ~/.cache/bazel-disk-cache  # cache bazel outputs and test runs
-          key: bazel-${{ runner.os }}-${{ env.cache-name }}-v0.1.0
-
-
       # Checks-out your repository under $GITHUB_WORKSPACE, which is the CWD for
       # the rest of the steps
       - uses: actions/checkout@v2
 
+      # Caches and restores bazelisk download directory, the bazel build directory.
+      - name: Bazel Tree and Disk Cache
+        uses: TerrenceHo/cache-always@v0.0.1
+        env:
+          cache-name: bazel-cache
+        with:
+          path: |
+            /home/runner/.cache/bazel
+            /home/runner/.cache/bazel-disk-cache
+          key: bazel-${{ runner.os }}-${{ env.cache-name }}-v0.3.0
+
       # build
       - name: Tests and builds the code
         run: bazel coverage //...
-        

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,11 +8,12 @@ gazelle(name = "gazelle")
 # gazelle:build_file_name BUILD.bazel
 #
 # Exclusions
-# gazelle:exclude: */vendor
-# gazelle:exclude: .bazel
-# gazelle:exclude: bazel-out
-# gazelle:exclude: **/node_modules
-# gazelle:exclude: third_party
+# gazelle:exclude */vendor
+# gazelle:exclude .bazel
+# gazelle:exclude bazel-out
+# gazelle:exclude **/node_modules
+# gazelle:exclude third_party
+# gazelle:exclude *_test.go
 #
 # Being explicit about naming conventions
 # gazelle:go_naming_convention import


### PR DESCRIPTION
**Summary**
Previous cache never updated caches on successful key hits, this now updates
caches successfully. This will also always run the cache step even if CI
fails.

Also properly run exclusions on bazel for gazelle

**Test Plan**
CI Test Commit

**Issue(s)**
