### PR TITLE
[fastlinks] Add bbolt stores implementation with routes

### DIFF
--- a/bazel/go/deps.bzl
+++ b/bazel/go/deps.bzl
@@ -811,6 +811,13 @@ def fetch_go_deps():
         version = "v3.0.0-20210107192922-496545a6307b",
     )
     go_repository(
+        name = "io_etcd_go_bbolt",
+        importpath = "go.etcd.io/bbolt",
+        sum = "h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=",
+        version = "v1.3.6",
+    )
+
+    go_repository(
         name = "io_etcd_go_etcd_api_v3",
         importpath = "go.etcd.io/etcd/api/v3",
         sum = "h1:GsV3S+OfZEOCNXdtNkBSR7kgLobAa/SO6tCxRa0GAYw=",

--- a/fastlinks/BUILD.bazel
+++ b/fastlinks/BUILD.bazel
@@ -1,5 +1,10 @@
 load("//bazel/go:default.bzl", "go_library", "go_test")
 
+alias(
+    name = "bin",
+    actual = "//fastlinks/cmd/fastlinks:fastlinks",
+)
+
 go_library(
     name = "fastlinks",
     srcs = ["app.go"],

--- a/fastlinks/app.go
+++ b/fastlinks/app.go
@@ -44,24 +44,24 @@ func Start(conf Config) {
 	logging.SetGlobalLogger(logger)
 
 	// Instantiate database connections
-	db, err := postgresql.NewConnection(
-		conf.DB.User,
-		conf.DB.Password,
-		conf.DB.DBName,
-		conf.DB.Port,
-		conf.DB.Host,
-		conf.DB.SSLMode,
-	)
-	defer db.Close()
-	if err != nil {
-		logging.Fatal(
-			"failed to connect to database",
-			zap.Error(err),
-		)
-	}
+	// db, err := postgresql.NewConnection(
+	// 	conf.DB.User,
+	// 	conf.DB.Password,
+	// 	conf.DB.DBName,
+	// 	conf.DB.Port,
+	// 	conf.DB.Host,
+	// 	conf.DB.SSLMode,
+	// )
+	// defer db.Close()
+	// if err != nil {
+	// 	logging.Fatal(
+	// 		"failed to connect to database",
+	// 		zap.Error(err),
+	// 	)
+	// }
 
 	// create stores
-	routesStore := postgresql.NewRoutesStore(db)
+	routesStore := postgresql.NewRoutesStore(nil)
 
 	// create services
 	healthService := services.NewHealthService(routesStore)
@@ -78,7 +78,7 @@ func Start(conf Config) {
 
 	go func() {
 		if err := app.Start(":" + conf.Port); err != http.ErrServerClosed {
-			app.Logger.Fatal("Shutting down the server.")
+            logging.Fatal("failed to start server", zap.Error(err))
 		}
 	}()
 

--- a/fastlinks/models/BUILD.bazel
+++ b/fastlinks/models/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel/go:default.bzl", "go_library")
+load("//bazel/go:default.bzl", "go_library", "go_test")
 
 go_library(
     name = "models",
@@ -8,4 +8,13 @@ go_library(
     ],
     importpath = "github.com/TerrenceHo/monorepo/fastlinks/models",
     visibility = ["//visibility:public"],
+    deps = ["//utils-go/stackerrors"],
+)
+
+go_test(
+    name = "models_test",
+    size = "small",
+    srcs = ["route_test.go"],
+    embed = [":models"],
+    deps = ["@com_github_stretchr_testify//assert"],
 )

--- a/fastlinks/models/route.go
+++ b/fastlinks/models/route.go
@@ -1,1 +1,81 @@
 package models
+
+import (
+	"bytes"
+	"encoding/gob"
+	"strings"
+
+	"github.com/TerrenceHo/monorepo/utils-go/stackerrors"
+)
+
+type Route struct {
+	// Key short URL name
+	Key string
+
+	// RedirectURL is the URL to redirect to
+	RedirectURL string
+
+	// ExtendedURL holds optional appended string to the RedirectURL
+	ExtendedURL string
+}
+
+func (r *Route) Encode() (*bytes.Buffer, error) {
+	var b bytes.Buffer
+	e := gob.NewEncoder(&b)
+	if err := e.Encode(*r); err != nil {
+		return nil, stackerrors.Wrap(err, "failed to serialize route to bytes")
+	}
+	return &b, nil
+}
+
+func (r *Route) Decode(b *bytes.Buffer) error {
+	d := gob.NewDecoder(b)
+	if err := d.Decode(r); err != nil {
+		return stackerrors.Wrap(err, "failed to deserialize route to struct")
+	}
+	return nil
+}
+
+type routeModelValFunc func(*Route) error
+
+// Validate validates that a Route object is proper. The current validations are
+// as follows:
+//  - Key is not empty
+//  - RedirectURL is not empty
+//  - If ExtendedURL is not empty, then RedirectURL must contain the format
+//    specifier "{}"
+func (r *Route) Validate() error {
+	return validateFuncs(r, hasKey, hasRedirect, validateExtendedURL)
+}
+
+func validateFuncs(r *Route, fns ...routeModelValFunc) error {
+	for _, fn := range fns {
+		if err := fn(r); err != nil {
+			return stackerrors.Wrap(err, "validation failed")
+		}
+	}
+	return nil
+}
+
+func hasKey(r *Route) error {
+	if r.Key == "" {
+		return stackerrors.New("Route must have a Key, was empty string")
+	}
+	return nil
+}
+
+func hasRedirect(r *Route) error {
+	if r.RedirectURL == "" {
+		return stackerrors.New("Route must have a RedirectURL, was empty string")
+	}
+	return nil
+}
+
+func validateExtendedURL(r *Route) error {
+	if r.ExtendedURL != "" {
+		if !strings.Contains(r.ExtendedURL, "{}") {
+			return stackerrors.New("If route has ExtendedURL, it must contain '{}'")
+		}
+	}
+	return nil
+}

--- a/fastlinks/models/route_test.go
+++ b/fastlinks/models/route_test.go
@@ -1,0 +1,119 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/TerrenceHo/monorepo/utils-go/stackerrors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRouteEncodeDecode(t *testing.T) {
+	assert := assert.New(t)
+
+	type testcase struct {
+		route *Route
+	}
+
+	testcases := []testcase{
+		{
+			route: &Route{
+				Key: "key",
+			},
+		},
+		{
+			route: &Route{
+				Key:         "key",
+				RedirectURL: "https://github.com/TerrenceHo/monorepo",
+			},
+		},
+		{
+			route: &Route{
+				Key:         "key",
+				RedirectURL: "https://github.com/TerrenceHo/monorepo",
+				ExtendedURL: "https://github.com/TerrenceHo/tree/master/{}",
+			},
+		},
+	}
+
+	for _, testcase := range testcases {
+		bytes, err := testcase.route.Encode()
+		if err != nil {
+			t.Logf("encoding returned error: %s", err.Error())
+		}
+		var r Route
+		err = r.Decode(bytes)
+		if err != nil {
+			t.Logf("decoding returned error: %s", err.Error())
+		}
+		assert.EqualValues(*testcase.route, r, "testcase route != decoded route")
+	}
+}
+
+func validationError(msg string) error {
+	return stackerrors.Wrap(
+		stackerrors.New(msg),
+		"validation failed",
+	)
+}
+
+func TestValidation(t *testing.T) {
+	assert := assert.New(t)
+
+	type testcase struct {
+		route *Route
+		err   error
+	}
+
+	testcases := []testcase{
+		{
+			route: &Route{
+				Key:         "key1",
+				RedirectURL: "https://github.com/TerrenceHo/monorepo",
+			},
+			err: nil,
+		},
+		{
+			route: &Route{
+				Key:         "key2",
+				RedirectURL: "https://github.com/TerrenceHo/monorepo",
+				ExtendedURL: "https://github.com/TerrenceHo/tree/master/{}",
+			},
+			err: nil,
+		},
+		{
+			route: &Route{},
+			err:   validationError("Route must have a Key, was empty string"),
+		},
+		{
+			route: &Route{
+				RedirectURL: "redirecturl",
+			},
+			err: validationError("Route must have a Key, was empty string"),
+		},
+		{
+			route: &Route{
+				Key: "key3",
+			},
+			err: validationError("Route must have a RedirectURL, was empty string"),
+		},
+		{
+			route: &Route{
+				Key:         "key4",
+				RedirectURL: "https://github.com/TerrenceHo/monorepo",
+				ExtendedURL: "https://github.com/TerrenceHo/tree/master/",
+			},
+			err: validationError("If route has ExtendedURL, it must contain '{}'"),
+		},
+	}
+
+	for _, testcase := range testcases {
+		err := testcase.route.Validate()
+		if testcase.err == nil {
+			if err != nil {
+				assert.Nilf(err, "Validate error should be nil, error: %s", err.Error())
+			}
+		} else {
+			assert.Equalf(testcase.err.Error(), err.Error(), "Validate error failed for key %s", testcase.route.Key)
+		}
+	}
+}

--- a/fastlinks/services/BUILD.bazel
+++ b/fastlinks/services/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
 
 go_test(
     name = "services_test",
+    size = "small",
     srcs = ["health_test.go"],
     embed = [":services"],
     deps = [

--- a/fastlinks/stores/bbolt/BUILD.bazel
+++ b/fastlinks/stores/bbolt/BUILD.bazel
@@ -1,0 +1,27 @@
+load("//bazel/go:default.bzl", "go_library", "go_test")
+
+go_library(
+    name = "bbolt",
+    srcs = [
+        "routes.go",
+        "stores.go",
+    ],
+    importpath = "github.com/TerrenceHo/monorepo/fastlinks/stores/bbolt",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//fastlinks/models",
+        "//utils-go/stackerrors",
+        "@io_etcd_go_bbolt//:bbolt",
+    ],
+)
+
+go_test(
+    name = "bbolt_test",
+    srcs = ["routes_test.go"],
+    embed = [":bbolt"],
+    deps = [
+        "//fastlinks/models",
+        "@com_github_stretchr_testify//assert",
+        "@io_etcd_go_bbolt//:bbolt",
+    ],
+)

--- a/fastlinks/stores/bbolt/routes.go
+++ b/fastlinks/stores/bbolt/routes.go
@@ -1,0 +1,111 @@
+package bbolt
+
+import (
+	"bytes"
+
+	"github.com/TerrenceHo/monorepo/fastlinks/models"
+	"github.com/TerrenceHo/monorepo/utils-go/stackerrors"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+type RoutesStore struct {
+	db     *bolt.DB
+	bucket string
+}
+
+func NewRoutesStore(db *bolt.DB, bucketName string) *RoutesStore {
+	return &RoutesStore{
+		db:     db,
+		bucket: bucketName,
+	}
+}
+
+func (rs *RoutesStore) Migrate() error {
+	if err := rs.db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte(rs.bucketName()))
+		if err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return stackerrors.Wrap(err, "failed to create bbolt bucket routes")
+	}
+
+	return nil
+}
+
+func (rs *RoutesStore) Name() string {
+	return "BBolt Routes Store"
+}
+
+func (rs *RoutesStore) Health() error {
+	return nil
+}
+
+func (rs *RoutesStore) GetByKey(key string) (*models.Route, error) {
+	var route models.Route
+	if err := rs.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(rs.bucketName())
+		routeBytes := bytes.NewBuffer(b.Get([]byte(key)))
+		err := (&route).Decode(routeBytes)
+		if err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return nil, stackerrors.Wrapf(err, "failed to get route with key %s", key)
+	}
+	return &route, nil
+}
+
+func (rs *RoutesStore) GetAll() ([]*models.Route, error) {
+	var routes []*models.Route
+
+	if err := rs.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(rs.bucketName())
+		c := b.Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			var route models.Route
+			routeBytes := bytes.NewBuffer(v)
+			err := (&route).Decode(routeBytes)
+			if err != nil {
+				return err
+			}
+			routes = append(routes, &route)
+		}
+		return nil
+	}); err != nil {
+		return nil, stackerrors.Wrap(err, "failed to query all routes")
+	}
+
+	return routes, nil
+}
+
+func (rs *RoutesStore) Add(route *models.Route) error {
+	if err := rs.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(rs.bucketName())
+		routeBytes, err := route.Encode()
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte(route.Key), routeBytes.Bytes())
+	}); err != nil {
+		return stackerrors.Wrapf(err, "failed to add route with key %s", route.Key)
+	}
+	return nil
+}
+
+func (rs *RoutesStore) Delete(key string) error {
+	if err := rs.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(rs.bucketName())
+		return b.Delete([]byte(key))
+	}); err != nil {
+		return stackerrors.Wrapf(err, "failed to delete route with key %s", key)
+	}
+	return nil
+}
+
+func (rs *RoutesStore) bucketName() []byte {
+	return []byte(rs.bucket)
+}

--- a/fastlinks/stores/bbolt/routes_test.go
+++ b/fastlinks/stores/bbolt/routes_test.go
@@ -1,0 +1,253 @@
+package bbolt
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/TerrenceHo/monorepo/fastlinks/models"
+	"github.com/TerrenceHo/monorepo/utils-go/stackerrors"
+	"github.com/stretchr/testify/assert"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+const testBucket = "test-bucket"
+
+func getTestDB(t *testing.T, dir string) *bolt.DB {
+	file, err := ioutil.TempFile(dir, "test.db")
+	db, err := NewConnection(file.Name(), 0600)
+	if err != nil {
+		t.Fatalf("failed to open bbolt db: %s", err.Error())
+	}
+	return db
+}
+
+func TestMigrate(t *testing.T) {
+	assert := assert.New(t)
+
+	dir := t.TempDir()
+
+	db := getTestDB(t, dir)
+
+	routesStore := NewRoutesStore(db, testBucket)
+	routesStore.Migrate()
+
+	err := db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(testBucket))
+
+		// if b is nil, then bucket does not exist
+		assert.NotNilf(b, "bucket %s should not be nil", testBucket)
+		return nil
+	})
+
+	if err != nil {
+		assert.Nilf(err, "error during migration: %s", err.Error())
+	}
+}
+
+func TestAdd(t *testing.T) {
+	assert := assert.New(t)
+
+	type testcase struct {
+		route *models.Route
+	}
+
+	testcases := []testcase{
+		{
+			route: &models.Route{
+				Key:         "testkey",
+				RedirectURL: "https://google.com",
+				ExtendedURL: "https://google.com/search/{}",
+			},
+		},
+		{
+			route: &models.Route{
+				Key:         "randKey",
+				RedirectURL: "https://random.com",
+			},
+		},
+	}
+
+	dir := t.TempDir()
+
+	db := getTestDB(t, dir)
+
+	routesStore := NewRoutesStore(db, testBucket)
+	routesStore.Migrate()
+
+	for _, testcase := range testcases {
+		err := routesStore.Add(testcase.route)
+		if err != nil {
+			assert.Fail("Add error: %s", err.Error())
+		}
+
+		// retrieve the route by key
+		var route models.Route
+		if err := db.View(func(tx *bolt.Tx) error {
+			b := tx.Bucket([]byte(testBucket))
+			routeBytes := bytes.NewBuffer(b.Get([]byte(testcase.route.Key)))
+			err := (&route).Decode(routeBytes)
+			if err != nil {
+				return err
+			}
+			return nil
+		}); err != nil {
+			assert.Nilf(err, "Error retrieving the stored route: %s", err.Error())
+		}
+		assert.Equalf(testcase.route, &route, "Added route not equivalent: %v != %v", testcase.route, route)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	assert := assert.New(t)
+
+	type testcase struct {
+		route *models.Route
+	}
+
+	testcases := []testcase{
+		{
+			route: &models.Route{
+				Key:         "testkey",
+				RedirectURL: "https://google.com",
+				ExtendedURL: "https://google.com/search/{}",
+			},
+		},
+		{
+			route: &models.Route{
+				Key:         "randKey",
+				RedirectURL: "https://random.com",
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	db := getTestDB(t, dir)
+
+	routesStore := NewRoutesStore(db, testBucket)
+	routesStore.Migrate()
+
+	for _, testcase := range testcases {
+		err := routesStore.Add(testcase.route)
+		if err != nil {
+			assert.Fail("Add error: %s", err.Error())
+		}
+
+		// delete the route by key
+		err = routesStore.Delete(testcase.route.Key)
+		if err != nil {
+			assert.Fail("Delete error: %s", err.Error())
+		}
+
+		// retrieve the route by key
+		if err := db.View(func(tx *bolt.Tx) error {
+			b := tx.Bucket([]byte(testBucket))
+			v := b.Get([]byte(testcase.route.Key))
+			if v != nil {
+				return stackerrors.Errorf("deleted key should return nil data, returned %v", v)
+			}
+			return nil
+		}); err != nil {
+			assert.Nilf(err, "Error retrieving the stored route: %s", err.Error())
+		}
+	}
+}
+
+func TestGet(t *testing.T) {
+	assert := assert.New(t)
+
+	type testcase struct {
+		route *models.Route
+	}
+
+	testcases := []testcase{
+		{
+			route: &models.Route{
+				Key:         "testkey",
+				RedirectURL: "https://google.com",
+				ExtendedURL: "https://google.com/search/{}",
+			},
+		},
+		{
+			route: &models.Route{
+				Key:         "randKey",
+				RedirectURL: "https://random.com",
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	db := getTestDB(t, dir)
+
+	routesStore := NewRoutesStore(db, testBucket)
+	routesStore.Migrate()
+
+	for _, testcase := range testcases {
+		err := routesStore.Add(testcase.route)
+		if err != nil {
+			assert.Fail("Add error: %s", err.Error())
+		}
+	}
+
+	for _, testcase := range testcases {
+		route, err := routesStore.GetByKey(testcase.route.Key)
+		assert.Nil(err, "GetByKey error should be nil")
+		assert.Equal(testcase.route, route, "route retrieved from Get not equal to expected")
+	}
+}
+
+func TestGetAll(t *testing.T) {
+	assert := assert.New(t)
+
+	type testcase struct {
+		route *models.Route
+	}
+
+	testcases := []testcase{
+		{
+			route: &models.Route{
+				Key:         "testkey",
+				RedirectURL: "https://google.com",
+				ExtendedURL: "https://google.com/search/{}",
+			},
+		},
+		{
+			route: &models.Route{
+				Key:         "randKey",
+				RedirectURL: "https://random.com",
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	db := getTestDB(t, dir)
+
+	routesStore := NewRoutesStore(db, testBucket)
+	routesStore.Migrate()
+
+	for _, testcase := range testcases {
+		err := routesStore.Add(testcase.route)
+		if err != nil {
+			assert.Fail("Add error: %s", err.Error())
+		}
+	}
+
+	routes, err := routesStore.GetAll()
+	if err != nil {
+		assert.Failf("GetAll failed", "GetAll error: %s", err.Error())
+	}
+	assert.Equal(len(testcases), len(routes), "length of returned data not equal")
+	for _, testcase := range testcases {
+		found := false
+		for _, route := range routes {
+			if route.Key == testcase.route.Key {
+				found = true
+				break
+			}
+		}
+		if !found {
+			assert.Failf("GetAll validation failed", "could not find route with Key %s", testcase.route.Key)
+		}
+	}
+}

--- a/fastlinks/stores/bbolt/stores.go
+++ b/fastlinks/stores/bbolt/stores.go
@@ -1,0 +1,18 @@
+package bbolt
+
+import (
+	"os"
+
+	"github.com/TerrenceHo/monorepo/utils-go/stackerrors"
+	bolt "go.etcd.io/bbolt"
+)
+
+type Store interface{}
+
+func NewConnection(filepath string, mode os.FileMode) (*bolt.DB, error) {
+	db, err := bolt.Open(filepath, mode, nil)
+	if err != nil {
+		return nil, stackerrors.Wrap(err, "bbolt DB failed to open")
+	}
+	return db, nil
+}

--- a/fastlinks/stores/postgresql/routes.go
+++ b/fastlinks/stores/postgresql/routes.go
@@ -13,7 +13,7 @@ func NewRoutesStore(db *sqlx.DB) *RoutesStore {
 }
 
 func (rs *RoutesStore) Name() string {
-	return "Routes Store"
+	return "Postgresql Routes Store"
 }
 
 func (rs *RoutesStore) Health() error {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/cobra v1.2.1 // indirect
 	github.com/spf13/viper v1.8.1 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
+	go.etcd.io/bbolt v1.3.6 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -374,6 +374,8 @@ github.com/yuin/goldmark v1.3.5 h1:dPmz1Snjq0kmkz159iL7S6WzdahUTHnHB5M56WFVifs=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1 h1:/vn0k+RBvwlxEmP5E7SZMqNxPhfMVFEJiykr15/0XKM=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
+go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.etcd.io/etcd/api/v3 v3.5.0 h1:GsV3S+OfZEOCNXdtNkBSR7kgLobAa/SO6tCxRa0GAYw=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.0 h1:2aQv6F436YnN7I4VbI8PPYrBhu+SmrTaADcf8Mi/6PU=
@@ -561,6 +563,7 @@ golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION

**Summary**
Add bbolt as the storage file backend, and implement routes storage.

**Test Plan**
Bazel CI

**Issue(s)**
Any issues that are linked to this PR. You can close issues with 
`close #<issue-num>`
