### PR TITLE
Add documentation for docker images

### DIFF
--- a/bazel/docker/README.md
+++ b/bazel/docker/README.md
@@ -1,0 +1,37 @@
+# Bazel Docker
+
+## Pushing Images
+
+If you want to push an image, import the `container_push` rule that is
+reexported from `//bazel/docker/rules.bzl`. The exported rule has some sane
+defaults set, but these defaults can be overridden. An example of using the
+`container_push` rule is below.
+
+Example:
+
+```
+load("//bazel/docker:rules.bzl", "container_push")
+
+container_push(
+    name = "push",
+    image = "<image rule>",
+    repository = "<user>/<repository name of image>",
+    visibility = ["//visibility:public"],
+)
+```
+
+A new image will not push if the image SHA256 digest is not changed (saving push
+time and image storage space).
+
+## CI Push
+
+If a new image is created and needs to be build/pushed with all commits, then
+add the image push rule over to the `multirun` rule in the root BIULD.bazel
+file. When the master CI passes in the GitHub actions after a PR lands, a job
+will invoke the `//:push_all` rule and push all images to their respective
+repositories.
+
+For pushes to succeed, you must allow the image repository to be pushed from the
+monorepo repository. Go to
+`https://github.com/users/<username>/packages/container/<image-name>/settings`
+and allow the monorepo to write to the image repository.

--- a/fastlinks/cmd/fastlinks/main.go
+++ b/fastlinks/cmd/fastlinks/main.go
@@ -32,7 +32,7 @@ func rootCmd(run func(cmd *cobra.Command, args []string)) *cobra.Command {
 	flags := mainCmd.Flags()
 
 	flags.String("env", "dev", "environment: test, dev, or prod")
-	flags.Bool("hidebanner", false, "hide banner")
+	flags.Bool("hidebanner", false, "hide fastlinks banner")
 	flags.String("host", "localhost", "hostserver on this hostname")
 	flags.StringP("port", "p", "12345", "host server on localhost:<port>")
 


### PR DESCRIPTION
**Summary**
Add README at `//bazel/docker/README.md` to describe how to use
`container_push` rule.

Additionally make innocuous change to fastlinks image to test actual
pushing to GHCR repository.

**Test Plan**
Bazel test and Master CI push

**Issue(s)**
