### PR TITLE
Fastlinks Local File

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -49,6 +49,10 @@ build --test_output=errors
 # show the test summary. Show detailed information about failed tests
 build --test_summary=detailed
 
+# inherit env vars to test
+build --action_env=HOME
+test --action_env=HOME
+
 
 ############################
 # Settings for local users #

--- a/README.md
+++ b/README.md
@@ -143,10 +143,6 @@ code). An example Python project is `//bazel/example-python`.
 
 Future work:
 - `mypy` typechecking support
-- Gazelle support
-    - Gazelle has extensions for other languages. Adding a Python extension in
-      Gazelle would enable us to automatically generate BUILD files for
-      Python, saves on a lot of work.
 
 ### Docker
 

--- a/fastlinks/BUILD.bazel
+++ b/fastlinks/BUILD.bazel
@@ -13,7 +13,9 @@ go_library(
     deps = [
         "//fastlinks/adapters/http",
         "//fastlinks/services",
+        "//fastlinks/stores/bbolt",
         "//fastlinks/stores/postgresql",
+        "//utils-go/file",
         "//utils-go/logging",
         "@com_github_labstack_echo_v4//:echo",
         "@com_github_labstack_echo_v4//middleware",

--- a/fastlinks/cmd/fastlinks/main.go
+++ b/fastlinks/cmd/fastlinks/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/TerrenceHo/monorepo/fastlinks"
 	"github.com/TerrenceHo/monorepo/utils-go/stackerrors"
@@ -22,6 +23,11 @@ const (
 )
 
 func rootCmd(run func(cmd *cobra.Command, args []string)) *cobra.Command {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	mainCmd := &cobra.Command{
 		Use:   "fastlinks",
 		Short: "fastlinks: simple URL redirector",
@@ -36,12 +42,17 @@ func rootCmd(run func(cmd *cobra.Command, args []string)) *cobra.Command {
 	flags.String("host", "localhost", "hostserver on this hostname")
 	flags.StringP("port", "p", "12345", "host server on localhost:<port>")
 
+	flags.StringP("storage", "s", "local", "storage options: local, postgres")
+
 	flags.String("db.user", "fastlinks", "database user")
 	flags.String("db.password", "password", "database password")
 	flags.String("db.dbname", "fastlinks", "database name")
 	flags.String("db.port", "5432", "database port")
 	flags.String("db.host", "localhost", "database host")
 	flags.String("db.sslmode", "disable", "database sslmode")
+
+	localFile := filepath.Join(home, ".fastlinks/fastlinks.db")
+	flags.String("local.file", localFile, "local file to store fastlinks data")
 
 	return mainCmd
 }
@@ -60,7 +71,7 @@ func serve(c *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	if !conf.Hidebanner {
-		fmt.Println(logo)
+		fmt.Print(logo)
 	}
 
 	fastlinks.Start(conf)

--- a/fastlinks/cmd/fastlinks/main_test.go
+++ b/fastlinks/cmd/fastlinks/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/TerrenceHo/monorepo/fastlinks"
@@ -28,6 +30,12 @@ func generateConfig(t *testing.T, args []string) fastlinks.Config {
 }
 
 func TestConfig(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	localFile := filepath.Join(home, ".fastlinks/fastlinks.db")
+
 	assert := assert.New(t)
 	type testcase struct {
 		args []string
@@ -41,6 +49,7 @@ func TestConfig(t *testing.T) {
 				Hidebanner: false,
 				Host:       "localhost",
 				Port:       "12345",
+				Storage:    "local",
 				DB: fastlinks.DBConfig{
 					User:     "fastlinks",
 					Password: "password",
@@ -48,6 +57,9 @@ func TestConfig(t *testing.T) {
 					Port:     "5432",
 					Host:     "localhost",
 					SSLMode:  "disable",
+				},
+				Local: fastlinks.LocalConfig{
+					File: localFile,
 				},
 			},
 		},
@@ -69,6 +81,7 @@ func TestConfig(t *testing.T) {
 				Hidebanner: true,
 				Host:       "google.com",
 				Port:       "5555",
+				Storage:    "local",
 				DB: fastlinks.DBConfig{
 					User:     "user",
 					Password: "newpassword",
@@ -76,6 +89,9 @@ func TestConfig(t *testing.T) {
 					Port:     "6666",
 					Host:     "newhost.com",
 					SSLMode:  "verify-full",
+				},
+				Local: fastlinks.LocalConfig{
+					File: localFile,
 				},
 			},
 		},

--- a/fastlinks/services/routes.go
+++ b/fastlinks/services/routes.go
@@ -1,6 +1,9 @@
 package services
 
-type RoutesStore interface{}
+type RoutesStore interface {
+	Name() string
+	Health() error
+}
 
 type RoutesService struct {
 	store RoutesStore

--- a/utils-go/file/BUILD.bazel
+++ b/utils-go/file/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//bazel/go:default.bzl", "go_library")
+
+go_library(
+    name = "file",
+    srcs = ["file.go"],
+    importpath = "github.com/TerrenceHo/monorepo/utils-go/file",
+    visibility = ["//visibility:public"],
+    deps = ["//utils-go/stackerrors"],
+)

--- a/utils-go/file/file.go
+++ b/utils-go/file/file.go
@@ -1,0 +1,19 @@
+package file
+
+import (
+	"os"
+
+	"github.com/TerrenceHo/monorepo/utils-go/stackerrors"
+)
+
+func CreateFileIfNotExists(fileName string) error {
+	_, err := os.Stat(fileName)
+	if os.IsNotExist(err) {
+		file, err := os.Create(fileName)
+		if err != nil {
+			return stackerrors.Wrapf(err, "failed to create file %s", fileName)
+		}
+		defer file.Close()
+	}
+	return nil
+}


### PR DESCRIPTION
**Summary**
Add support for the local file storage into fastlinks. There is now a
configuration option to switch between the database storage and the
local file bbolt storage. By default it will use the local storage.

A new utility function to "touch" a file was added into utils-go. The
intent is to create a file if it did not yet exist.

Because Bazel strips environment variables during testing, there, we
must export the `$HOME` variable over to the tests, so that. This should
be safe env var because the `$HOME` env var should not change very often
(usually never) between runs and is cache friendly.

**Test Plan**
Bazel test

**Issue(s)**
Any issues that are linked to this PR. You can close issues with 
`close #<issue-num>`
