### PR TITLE
[bazel] Add rule to install binaries locally

### DIFF
--- a/bazel/local/rules.bzl
+++ b/bazel/local/rules.bzl
@@ -1,0 +1,27 @@
+def _local_install_impl(ctx):
+    target = ctx.attr.target
+    shell_commands = ""
+
+    for s in ctx.files.srcs:
+        shell_commands += "echo Copying %s to %s\n" % (s.short_path, target)
+        shell_commands += "sudo cp %s %s\n" % (s.short_path, target)
+
+    ctx.actions.write(
+        output = ctx.outputs.executable,
+        is_executable = True,
+        content = shell_commands,
+    )
+    runfiles = ctx.runfiles(files = ctx.files.srcs)
+    return DefaultInfo(
+        executable = ctx.outputs.executable,
+        runfiles = runfiles,
+    )
+
+local_install = rule(
+    executable = True,
+    implementation = _local_install_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "target": attr.string(default = "/usr/local/bin", doc = "Local install target directory"),
+    },
+)

--- a/fastlinks/BUILD.bazel
+++ b/fastlinks/BUILD.bazel
@@ -5,6 +5,16 @@ alias(
     actual = "//fastlinks/cmd/fastlinks:fastlinks",
 )
 
+alias(
+    name = "image",
+    actual = "//fastlinks/cmd/fastlinks:fastlinks_image",
+)
+
+alias(
+    name = "install",
+    actual = "//fastlinks/cmd/fastlinks:install",
+)
+
 go_library(
     name = "fastlinks",
     srcs = ["app.go"],

--- a/fastlinks/cmd/fastlinks/BUILD.bazel
+++ b/fastlinks/cmd/fastlinks/BUILD.bazel
@@ -1,5 +1,6 @@
 load("//bazel/go:default.bzl", "go_binary", "go_image", "go_library", "go_test")
 load("//bazel/docker:rules.bzl", "container_push")
+load("//bazel/local:rules.bzl", "local_install")
 
 go_library(
     name = "fastlinks_lib",
@@ -48,5 +49,11 @@ container_push(
     name = "push",
     image = ":fastlinks_image",
     repository = "terrenceho/fastlinks",
+    visibility = ["//visibility:public"],
+)
+
+local_install(
+    name = "install",
+    srcs = [":fastlinks"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
**Summary**
Add `local_install` rule to install binaries locally, by default
installs to `usr/local/bin`

**Test Plan**
`bazel test //...`

And ran the command locally, working as expected

**Issue(s)**
Any issues that are linked to this PR. You can close issues with 
`close #<issue-num>`
